### PR TITLE
Adding option to tune thresholds as a part of  training process.

### DIFF
--- a/XMLC/src/Learner/AbstractLearner.java
+++ b/XMLC/src/Learner/AbstractLearner.java
@@ -26,8 +26,14 @@ public abstract class AbstractLearner implements Serializable{
 
 	private static Logger logger = LoggerFactory.getLogger(AbstractLearner.class);
 
-	protected int m = 0; // num of labels
-	protected int d = 0; // number of features
+	/**
+	 * Number of labels.
+	 */
+	protected int m = 0; 
+	/**
+	 * Number of features.
+	 */
+	protected int d = 0; 
 
 
 	transient protected Properties properties = null;

--- a/XMLC/src/Learner/MLL.java
+++ b/XMLC/src/Learner/MLL.java
@@ -39,7 +39,9 @@ public class MLL extends AbstractLearner {
 	
 	
 	transient protected FeatureHasher fh = null;
-	
+	/**
+	 * Hashed dimension, i.e. number of ML hashed features.
+	 */	
 	protected int hd;
 
 

--- a/XMLC/src/Learner/PLT.java
+++ b/XMLC/src/Learner/PLT.java
@@ -1,9 +1,6 @@
 package Learner;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.PriorityQueue;
 import java.util.Properties;
@@ -23,6 +20,7 @@ import Data.NodePLT;
 import IO.DataManager;
 import preprocessing.FeatureHasher;
 import preprocessing.FeatureHasherFactory;
+import threshold.ThresholdTunerFactory;
 import util.CompleteTree;
 import util.HuffmanTree;
 import util.PrecomputedTree;
@@ -34,9 +32,9 @@ public class PLT extends AbstractLearner {
 	/**
 	 * Number of node of the trees
 	 */
-	transient protected int t = 0;	
+	transient protected int t = 0;
 	protected Tree tree = null;
-	
+
 	/**
 	 * Order of the tree (k-ary).
 	 */
@@ -45,10 +43,9 @@ public class PLT extends AbstractLearner {
 	protected String treeFile = null;
 
 	transient protected int T = 1;
-	//transient protected AVTable traindata = null;
+	// transient protected AVTable traindata = null;
 	transient protected DataManager traindata = null;
-	
-	
+
 	transient protected FeatureHasher fh = null;
 	protected String hasher = "Universal";
 	protected int fhseed = 1;
@@ -56,11 +53,11 @@ public class PLT extends AbstractLearner {
 	 * Hashed dimension, i.e. number of ML hashed features.
 	 */
 	protected int hd;
-	
+
 	protected double[] bias;
 	protected double[] w = null;
-	
-	transient protected int[] Tarray = null;	
+
+	transient protected int[] Tarray = null;
 	protected double[] scalararray = null;
 
 	protected double gamma = 0; // learning rate
@@ -69,119 +66,123 @@ public class PLT extends AbstractLearner {
 	transient protected double learningRate = 1.0;
 	protected double scalar = 1.0;
 	protected double lambda = 0.00001;
-	protected int epochs = 1;	
-		
-	
+	protected int epochs = 1;
+
 	public PLT(Properties properties) {
 		super(properties);
-		
-		System.out.println("#####################################################" );
-		System.out.println("#### Learner: PLT" );
+
+		System.out.println("#####################################################");
+		System.out.println("#### Learner: PLT");
 		// learning rate
 		this.gamma = Double.parseDouble(this.properties.getProperty("gamma", "1.0"));
-		logger.info("#### gamma: " + this.gamma );
+		logger.info("#### gamma: " + this.gamma);
 
 		// scalar
 		this.lambda = Double.parseDouble(this.properties.getProperty("lambda", "1.0"));
-		logger.info("#### lambda: " + this.lambda );
+		logger.info("#### lambda: " + this.lambda);
 
 		// epochs
 		this.epochs = Integer.parseInt(this.properties.getProperty("epochs", "30"));
-		logger.info("#### epochs: " + this.epochs );
+		logger.info("#### epochs: " + this.epochs);
 
 		// epochs
 		this.hasher = this.properties.getProperty("hasher", "Mask");
-		logger.info("#### Hasher: " + this.hasher );
-		
-		
-		this.hd = Integer.parseInt(this.properties.getProperty("MLFeatureHashing", "50000000")); 
-		logger.info("#### Number of ML hashed features: " + this.hd );
-		
+		logger.info("#### Hasher: " + this.hasher);
+
+		this.hd = Integer.parseInt(this.properties.getProperty("MLFeatureHashing", "50000000"));
+		logger.info("#### Number of ML hashed features: " + this.hd);
 
 		// k-ary tree
 		this.k = Integer.parseInt(this.properties.getProperty("k", "2"));
-		logger.info("#### k (order of the tree): " + this.k );
+		logger.info("#### k (order of the tree): " + this.k);
 
 		// tree type (Complete, Precomputed, Huffman)
 		this.treeType = this.properties.getProperty("treeType", "Complete");
-		logger.info("#### tree type " + this.treeType );
+		logger.info("#### tree type " + this.treeType);
 
 		// tree file name
 		this.treeFile = this.properties.getProperty("treeFile", null);
-		logger.info("#### tree file name " + this.treeFile );
+		logger.info("#### tree file name " + this.treeFile);
 
-		System.out.println("#####################################################" );
+		System.out.println("#####################################################");
 
 	}
 
 	public void printParameters() {
 		super.printParameters();
-		logger.info("#### gamma: " + this.gamma );
-		logger.info("#### lambda: " + this.lambda );		
-		logger.info("#### epochs: " + this.epochs );
-		logger.info("#### Hasher: " + this.hasher );
-		logger.info("#### Number of ML hashed features: " + this.hd );
-		logger.info("#### k (order of the tree): " + this.k );		
-		logger.info("#### tree type: " + this.treeType );
-		logger.info("#### tree file: " + this.treeFile );
+		logger.info("#### gamma: " + this.gamma);
+		logger.info("#### lambda: " + this.lambda);
+		logger.info("#### epochs: " + this.epochs);
+		logger.info("#### Hasher: " + this.hasher);
+		logger.info("#### Number of ML hashed features: " + this.hd);
+		logger.info("#### k (order of the tree): " + this.k);
+		logger.info("#### tree type: " + this.treeType);
+		logger.info("#### tree file: " + this.treeFile);
 	}
-	
-	
+
 	@Override
 	public void allocateClassifiers(DataManager data) {
 		this.traindata = data;
 		this.m = data.getNumberOfLabels();
 		this.d = data.getNumberOfFeatures();
-		
-		switch (this.treeType){
-			case CompleteTree.name:
-				this.tree = new CompleteTree(this.k, this.m);
-				break;
-			case PrecomputedTree.name:
-				this.tree = new PrecomputedTree(this.treeFile);
-				break;
-			case HuffmanTree.name:
-				this.tree = new HuffmanTree(data, this.treeFile);
-				break;
-			default:
-				System.err.println("Unknown tree type!");
-				System.exit(-1);
-		}
-		this.t = this.tree.getSize(); 
 
-		logger.info( "#### Num. of labels: " + this.m + " Dim: " + this.d );
-		logger.info( "#### Num. of node of the trees: " + this.t  );
-		logger.info("#####################################################" );
-			
+		switch (this.treeType) {
+		case CompleteTree.name:
+			this.tree = new CompleteTree(this.k, this.m);
+			break;
+		case PrecomputedTree.name:
+			this.tree = new PrecomputedTree(this.treeFile);
+			break;
+		case HuffmanTree.name:
+			this.tree = new HuffmanTree(data, this.treeFile);
+			break;
+		default:
+			System.err.println("Unknown tree type!");
+			System.exit(-1);
+		}
+		this.t = this.tree.getSize();
+
+		thresholdTuner = ThresholdTunerFactory.createThresholdTuner(m, properties);
+		if (thresholdTuner != null)
+			logger.info("#### thresholdTuner set to " + thresholdTuner.getClass()
+					.getName());
+		else
+			logger.info("#### thresholdTuner can't be instantiated. Threshold will not be tuned during training.");
+
+		logger.info("#### Num. of labels: " + this.m + " Dim: " + this.d);
+		logger.info("#### Num. of node of the trees: " + this.t);
+		logger.info("#####################################################");
+
 		this.fh = FeatureHasherFactory.createFeatureHasher(this.hasher, fhseed, this.hd, this.t);
-		
-		logger.info( "Allocate the learners..." );
+
+		logger.info("Allocate the learners...");
 
 		this.w = new double[this.hd];
 		this.thresholds = new double[this.t];
 		this.bias = new double[this.t];
-		
+
 		for (int i = 0; i < this.t; i++) {
 			this.thresholds[i] = 0.5;
 		}
 
+		if (thresholdTuner != null)
+			setThresholds(thresholdTuner.getTunedThresholds(null));
+
 		this.Tarray = new int[this.t];
 		this.scalararray = new double[this.t];
 		Arrays.fill(this.Tarray, 1);
-		Arrays.fill(this.scalararray, 1.0);		
+		Arrays.fill(this.scalararray, 1.0);
 	}
 
-	
 	@Override
-	public void train(DataManager data) {		
+	public void train(DataManager data) {
 		for (int ep = 0; ep < this.epochs; ep++) {
 
-			logger.info("#############--> BEGIN of Epoch: {} ({})", (ep + 1), this.epochs );
+			logger.info("#############--> BEGIN of Epoch: {} ({})", (ep + 1), this.epochs);
 			// random permutation
-			
-			
-			while( data.hasNext() == true ){
-				
+
+			while (data.hasNext() == true) {
+
 				Instance instance = data.getNextInstance();
 
 				HashSet<Integer> positiveTreeIndices = new HashSet<Integer>();
@@ -189,111 +190,129 @@ public class PLT extends AbstractLearner {
 
 				for (int j = 0; j < instance.y.length; j++) {
 
-					int treeIndex = this.tree.getTreeIndex(instance.y[j]); // + traindata.m - 1;
+					int treeIndex = this.tree.getTreeIndex(instance.y[j]); // +
+																			// traindata.m
+																			// -
+																			// 1;
 					positiveTreeIndices.add(treeIndex);
 
-					while(treeIndex > 0) {
+					while (treeIndex > 0) {
 
-						treeIndex = (int) this.tree.getParent(treeIndex); // Math.floor((treeIndex - 1)/2);
+						treeIndex = (int) this.tree.getParent(treeIndex); // Math.floor((treeIndex
+																			// -
+																			// 1)/2);
 						positiveTreeIndices.add(treeIndex);
 
 					}
 				}
 
-				if(positiveTreeIndices.size() == 0) {
+				if (positiveTreeIndices.size() == 0) {
 
 					negativeTreeIndices.add(0);
 
 				} else {
 
-					
-					for(int positiveNode : positiveTreeIndices) {
-						
-						if(!this.tree.isLeaf(positiveNode)) {
-							
-							for(int childNode: this.tree.getChildNodes(positiveNode)) {
-								
-								if(!positiveTreeIndices.contains(childNode)) {
+					for (int positiveNode : positiveTreeIndices) {
+
+						if (!this.tree.isLeaf(positiveNode)) {
+
+							for (int childNode : this.tree.getChildNodes(positiveNode)) {
+
+								if (!positiveTreeIndices.contains(childNode)) {
 									negativeTreeIndices.add(childNode);
 								}
-								
+
 							}
-							
+
 						}
-						
+
 					}
 				}
 
-				//logger.info("Negative tree indices: " + negativeTreeIndices.toString());
+				// logger.info("Negative tree indices: " +
+				// negativeTreeIndices.toString());
 
-				for(int j:positiveTreeIndices) {
+				for (int j : positiveTreeIndices) {
 
-					double posterior = getPartialPosteriors(instance.x,j);
-					double inc = -(1.0 - posterior); 
+					double posterior = getPartialPosteriors(instance.x, j);
+					double inc = -(1.0 - posterior);
 
 					updatedPosteriors(instance.x, j, inc);
 				}
 
-				for(int j:negativeTreeIndices) {
+				for (int j : negativeTreeIndices) {
 
-					if(j >= this.t) logger.info("ALARM");
+					if (j >= this.t)
+						logger.info("ALARM");
 
-					double posterior = getPartialPosteriors(instance.x,j);
-					double inc = -(0.0 - posterior); 
-					
+					double posterior = getPartialPosteriors(instance.x, j);
+					double inc = -(0.0 - posterior);
+
 					updatedPosteriors(instance.x, j, inc);
 				}
 
 				this.T++;
 
 				if ((this.T % 100000) == 0) {
-					logger.info( "\t --> Epoch: " + (ep+1) + " (" + this.epochs + ")" + "\tSample: "+ this.T );
+					logger.info("\t --> Epoch: " + (ep + 1) + " (" + this.epochs + ")" + "\tSample: " + this.T);
 				}
 			}
 			data.reset();
-			
-			logger.info("--> END of Epoch: " + (ep + 1) + " (" + this.epochs + ")" );
+
+			logger.info("--> END of Epoch: " + (ep + 1) + " (" + this.epochs + ")");
 		}
-		
+
 		int zeroW = 0;
 		double sumW = 0;
 		int maxNonZero = 0;
 		int index = 0;
-		for(double weight : w) {
-			if(weight == 0) zeroW++;
-			else maxNonZero = index;
+		for (double weight : w) {
+			if (weight == 0)
+				zeroW++;
+			else
+				maxNonZero = index;
 			sumW += weight;
 			index++;
 		}
-		logger.info("Hash weights (lenght, zeros, nonzeros, ratio, sumW, last nonzero): " + w.length + ", " + zeroW + ", " + (w.length - zeroW) + ", " + (double) (w.length - zeroW)/(double) w.length + ", " + sumW + ", " + maxNonZero);
+		logger.info("Hash weights (lenght, zeros, nonzeros, ratio, sumW, last nonzero): " + w.length + ", " + zeroW
+				+ ", " + (w.length - zeroW) + ", " + (double) (w.length - zeroW) / (double) w.length + ", " + sumW
+				+ ", " + maxNonZero);
+
+		// tuning thresholds from learner is optional as of now. if made
+		// mandatory, then this kind of checks can be removed.
+		if (this.thresholdTuner != null) {
+			tuneThreshold(data);
+		}
 	}
 
+	
 
-	protected void updatedPosteriors( AVPair[] x, int label, double inc) {
-			
+	protected void updatedPosteriors(AVPair[] x, int label, double inc) {
+
 		this.learningRate = this.gamma / (1 + this.gamma * this.lambda * this.Tarray[label]);
 		this.Tarray[label]++;
 		this.scalararray[label] *= (1 + this.learningRate * this.lambda);
-		
+
 		int n = x.length;
-		
-		for(int i = 0; i < n; i++) {
+
+		for (int i = 0; i < n; i++) {
 
 			int index = fh.getIndex(label, x[i].index);
 			int sign = fh.getSign(label, x[i].index);
-			
+
 			double gradient = this.scalararray[label] * inc * (x[i].value * sign);
-			double update = (this.learningRate * gradient);// / this.scalar;		
-			this.w[index] -= update; 
-			
+			double update = (this.learningRate * gradient);// / this.scalar;
+			this.w[index] -= update;
+
 		}
-		
+
 		double gradient = this.scalararray[label] * inc;
-		double update = (this.learningRate * gradient);//  / this.scalar;		
+		double update = (this.learningRate * gradient);// / this.scalar;
 		this.bias[label] -= update;
-		//logger.info("bias -> gradient, scalar, update: " + gradient + ", " + scalar +", " + update);
+		// logger.info("bias -> gradient, scalar, update: " + gradient + ", " +
+		// scalar +", " + update);
 	}
-	
+
 	/**
 	 * Computes and returns {@code sigmoid(fh(x).dot(weight) + bias[label])}
 	 * 
@@ -302,47 +321,45 @@ public class PLT extends AbstractLearner {
 	 * @param label
 	 *            Node index of PLT.
 	 * @return Class (1 or 0) probability estimate at node {@code label} for the
-	 *         given instance {@code x}, as per current weight vector and bias at
-	 *         node {@code label}.
+	 *         given instance {@code x}, as per current weight vector and bias
+	 *         at node {@code label}.
 	 */
 	public double getPartialPosteriors(AVPair[] x, int label) {
 		double posterior = 0.0;
-		
-		
+
 		for (int i = 0; i < x.length; i++) {
-			
-			int hi = fh.getIndex(label,  x[i].index); 
+
+			int hi = fh.getIndex(label, x[i].index);
 			int sign = fh.getSign(label, x[i].index);
-			posterior += (x[i].value *sign) * (1/this.scalararray[label]) * this.w[hi];
+			posterior += (x[i].value * sign) * (1 / this.scalararray[label]) * this.w[hi];
 		}
-		
-		posterior += (1/this.scalararray[label]) * this.bias[label]; 
-		posterior = s.value(posterior);		
-		
+
+		posterior += (1 / this.scalararray[label]) * this.bias[label];
+		posterior = s.value(posterior);
+
 		return posterior;
 
 	}
 
-	protected Object readResolve(){
-		switch (this.treeType){
-			case CompleteTree.name:
-				this.tree = new CompleteTree(this.k, this.m);
-				break;
-			case PrecomputedTree.name:
-				this.tree = new PrecomputedTree(this.treeFile);
-				break;
-			case HuffmanTree.name:
-				this.tree = new HuffmanTree(this.treeFile);
-				break;
-			default:
-				System.err.println("Unknown tree type!");
-				System.exit(-1);				
+	protected Object readResolve() {
+		switch (this.treeType) {
+		case CompleteTree.name:
+			this.tree = new CompleteTree(this.k, this.m);
+			break;
+		case PrecomputedTree.name:
+			this.tree = new PrecomputedTree(this.treeFile);
+			break;
+		case HuffmanTree.name:
+			this.tree = new HuffmanTree(this.treeFile);
+			break;
+		default:
+			System.err.println("Unknown tree type!");
+			System.exit(-1);
 		}
 		this.t = this.tree.getSize();
 		this.fh = FeatureHasherFactory.createFeatureHasher(this.hasher, fhseed, this.hd, this.t);
 		return this;
 	}
-
 
 	@Override
 	public double getPosteriors(AVPair[] x, int label) {
@@ -352,13 +369,15 @@ public class PLT extends AbstractLearner {
 
 		posterior *= getPartialPosteriors(x, treeIndex);
 
-		while(treeIndex > 0) {
+		while (treeIndex > 0) {
 
-			treeIndex = this.tree.getParent(treeIndex); //Math.floor((treeIndex - 1)/2);
+			treeIndex = this.tree.getParent(treeIndex); // Math.floor((treeIndex
+														// - 1)/2);
 			posterior *= getPartialPosteriors(x, treeIndex);
 
 		}
-		//if(posterior > 0.5) logger.info("Posterior: " + posterior + "Label: " + label);
+		// if(posterior > 0.5) logger.info("Posterior: " + posterior + "Label: "
+		// + label);
 		return posterior;
 	}
 
@@ -367,26 +386,26 @@ public class PLT extends AbstractLearner {
 
 		HashSet<Integer> positiveLabels = new HashSet<Integer>();
 
-	    NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
+		NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
 
-		PriorityQueue<NodePLT> queue = new PriorityQueue<NodePLT>(11,nodeComparator);
+		PriorityQueue<NodePLT> queue = new PriorityQueue<NodePLT>(11, nodeComparator);
 
-		queue.add(new NodePLT(0,1.0));
+		queue.add(new NodePLT(0, 1.0));
 
-		while(!queue.isEmpty()) {
+		while (!queue.isEmpty()) {
 
 			NodePLT node = queue.poll();
 
 			double currentP = node.p * getPartialPosteriors(x, node.treeIndex);
 
-			if(currentP >= this.thresholds[node.treeIndex]) {
+			if (currentP >= this.thresholds[node.treeIndex]) {
 
-				if(!this.tree.isLeaf(node.treeIndex)) {
-					
-					for(int childNode: this.tree.getChildNodes(node.treeIndex)) {
+				if (!this.tree.isLeaf(node.treeIndex)) {
+
+					for (int childNode : this.tree.getChildNodes(node.treeIndex)) {
 						queue.add(new NodePLT(childNode, currentP));
 					}
-					
+
 				} else {
 
 					positiveLabels.add(this.tree.getLabelIndex(node.treeIndex));
@@ -395,202 +414,191 @@ public class PLT extends AbstractLearner {
 			}
 		}
 
-		//logger.info("Predicted labels: " + positiveLabels.toString());
+		// logger.info("Predicted labels: " + positiveLabels.toString());
 
 		return positiveLabels;
 	}
 
-	
 	@Override
 	public PriorityQueue<ComparablePair> getPositiveLabelsAndPosteriors(AVPair[] x) {
 		PriorityQueue<ComparablePair> positiveLabels = new PriorityQueue<>();
 
-	    NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
+		NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
 
 		PriorityQueue<NodePLT> queue = new PriorityQueue<NodePLT>(11, nodeComparator);
 
-		queue.add(new NodePLT(0,1.0));
+		queue.add(new NodePLT(0, 1.0));
 
-		while(!queue.isEmpty()) {
+		while (!queue.isEmpty()) {
 
 			NodePLT node = queue.poll();
 
 			double currentP = node.p * getPartialPosteriors(x, node.treeIndex);
 
-			if(currentP > this.thresholds[node.treeIndex]) {
+			if (currentP > this.thresholds[node.treeIndex]) {
 
-				if(!this.tree.isLeaf(node.treeIndex)) {
-					
-					for(int childNode: this.tree.getChildNodes(node.treeIndex)) {
+				if (!this.tree.isLeaf(node.treeIndex)) {
+
+					for (int childNode : this.tree.getChildNodes(node.treeIndex)) {
 						queue.add(new NodePLT(childNode, currentP));
 					}
-					
+
 				} else {
 
-					positiveLabels.add(new ComparablePair( currentP, this.tree.getLabelIndex(node.treeIndex)));
+					positiveLabels.add(new ComparablePair(currentP, this.tree.getLabelIndex(node.treeIndex)));
 
 				}
 			}
 		}
 
-		//logger.info("Predicted labels: " + positiveLabels.toString());
+		// logger.info("Predicted labels: " + positiveLabels.toString());
 
 		return positiveLabels;
 	}
-	
-	
+
 	@Override
 	public int[] getTopkLabels(AVPair[] x, int k) {
 		int[] positiveLabels = new int[k];
-		int indi =0;
+		int indi = 0;
 
-	    NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
+		NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
 
 		PriorityQueue<NodePLT> queue = new PriorityQueue<>(11, nodeComparator);
 
-		queue.add(new NodePLT(0,1.0));
+		queue.add(new NodePLT(0, 1.0));
 
-		while(!queue.isEmpty()) {
+		while (!queue.isEmpty()) {
 
 			NodePLT node = queue.poll();
 
 			double currentP = node.p * getPartialPosteriors(x, node.treeIndex);
 
-			
-			if(!this.tree.isLeaf(node.treeIndex)) {
-				
-				for(int childNode: this.tree.getChildNodes(node.treeIndex)) {
+			if (!this.tree.isLeaf(node.treeIndex)) {
+
+				for (int childNode : this.tree.getChildNodes(node.treeIndex)) {
 					queue.add(new NodePLT(childNode, currentP));
 				}
-				
+
 			} else {
 				positiveLabels[indi++] = this.tree.getLabelIndex(node.treeIndex);
 			}
-			
-			if (indi>=k) { 
+
+			if (indi >= k) {
 				break;
 			}
 		}
-	
-		//logger.info("Predicted labels: " + positiveLabels.toString());
+
+		// logger.info("Predicted labels: " + positiveLabels.toString());
 
 		return positiveLabels;
 	}
-	
-	
-	
+
 	@Override
 	public void setThreshold(int label, double t) {
-		
+
 		int treeIndex = this.tree.getTreeIndex(label);
 		this.thresholds[treeIndex] = t;
-		
-		while(treeIndex > 0) {
-			treeIndex =  this.tree.getParent(treeIndex);
+
+		while (treeIndex > 0) {
+			treeIndex = this.tree.getParent(treeIndex);
 			double minThreshold = Double.MAX_VALUE;
-			for(int childNode: this.tree.getChildNodes(treeIndex)) {
-				minThreshold = this.thresholds[childNode] < minThreshold?  this.thresholds[childNode] : minThreshold;
-			}	
+			for (int childNode : this.tree.getChildNodes(treeIndex)) {
+				minThreshold = this.thresholds[childNode] < minThreshold ? this.thresholds[childNode] : minThreshold;
+			}
 			this.thresholds[treeIndex] = minThreshold;
 		}
-		
+
 	}
 
-	
-	
 	public void setThresholds(double[] t) {
-		
-		for(int j = 0; j < t.length; j++) {
+
+		for (int j = 0; j < t.length; j++) {
 			this.thresholds[this.tree.getTreeIndex(j)] = t[j];
 		}
-		
-		for(int j = this.tree.getNumberOfInternalNodes()-1; j >= 0; j--) {
-			
+
+		for (int j = this.tree.getNumberOfInternalNodes() - 1; j >= 0; j--) {
+
 			double minThreshold = Double.MAX_VALUE;
-			for(int childNode: this.tree.getChildNodes(j)) {
-				minThreshold = this.thresholds[childNode] < minThreshold?  this.thresholds[childNode] : minThreshold;
+			for (int childNode : this.tree.getChildNodes(j)) {
+				minThreshold = this.thresholds[childNode] < minThreshold ? this.thresholds[childNode] : minThreshold;
 			}
-			
-			this.thresholds[j] = minThreshold; 
+
+			this.thresholds[j] = minThreshold;
 		}
-		
-		//for( int i=0; i < this.thresholds.length; i++ )
-		//	logger.info( "Threshold: " + i + " Th: " + String.format("%.4f", this.thresholds[i])  );
-	
-		
+
+		// for( int i=0; i < this.thresholds.length; i++ )
+		// logger.info( "Threshold: " + i + " Th: " + String.format("%.4f",
+		// this.thresholds[i]) );
+
 	}
 
-
-	
 	@Override
 	public HashSet<EstimatePair> getSparseProbabilityEstimates(AVPair[] x, double threshold) {
 
 		HashSet<EstimatePair> positiveLabels = new HashSet<EstimatePair>();
 
-	    NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
+		NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
 
 		PriorityQueue<NodePLT> queue = new PriorityQueue<NodePLT>(11, nodeComparator);
 
-		queue.add(new NodePLT(0,1.0));
+		queue.add(new NodePLT(0, 1.0));
 
-		while(!queue.isEmpty()) {
+		while (!queue.isEmpty()) {
 
 			NodePLT node = queue.poll();
 
 			double currentP = node.p * getPartialPosteriors(x, node.treeIndex);
 
-			if(currentP >= threshold) {
+			if (currentP >= threshold) {
 
-				if(!this.tree.isLeaf(node.treeIndex)) {
-					
-					for(int childNode: this.tree.getChildNodes(node.treeIndex)) {
+				if (!this.tree.isLeaf(node.treeIndex)) {
+
+					for (int childNode : this.tree.getChildNodes(node.treeIndex)) {
 						queue.add(new NodePLT(childNode, currentP));
 					}
-					
+
 				} else {
-				
+
 					positiveLabels.add(new EstimatePair(this.tree.getLabelIndex(node.treeIndex), currentP));
 
 				}
 			}
 		}
 
-		//logger.info("Predicted labels: " + positiveLabels.toString());
+		// logger.info("Predicted labels: " + positiveLabels.toString());
 
 		return positiveLabels;
 	}
-
-
 
 	public TreeSet<EstimatePair> getTopKEstimates(AVPair[] x, int k) {
 
 		TreeSet<EstimatePair> positiveLabels = new TreeSet<EstimatePair>();
 
-	    int foundTop = 0;
-	    
-	    NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
+		int foundTop = 0;
+
+		NodeComparatorPLT nodeComparator = new NodeComparatorPLT();
 
 		PriorityQueue<NodePLT> queue = new PriorityQueue<NodePLT>(11, nodeComparator);
 
-		queue.add(new NodePLT(0,1.0));
-		
-		while(!queue.isEmpty() && (foundTop < k)) {
+		queue.add(new NodePLT(0, 1.0));
+
+		while (!queue.isEmpty() && (foundTop < k)) {
 
 			NodePLT node = queue.poll();
 
 			double currentP = node.p;
-			
-			if(!this.tree.isLeaf(node.treeIndex)) {
-				
-				for(int childNode: this.tree.getChildNodes(node.treeIndex)) {
+
+			if (!this.tree.isLeaf(node.treeIndex)) {
+
+				for (int childNode : this.tree.getChildNodes(node.treeIndex)) {
 					queue.add(new NodePLT(childNode, currentP * getPartialPosteriors(x, childNode)));
 				}
-				
+
 			} else {
-				
+
 				positiveLabels.add(new EstimatePair(this.tree.getLabelIndex(node.treeIndex), currentP));
 				foundTop++;
-				
+
 			}
 		}
 

--- a/XMLC/src/Learner/PLT.java
+++ b/XMLC/src/Learner/PLT.java
@@ -31,9 +31,15 @@ import util.Tree;
 public class PLT extends AbstractLearner {
 	private static final long serialVersionUID = 1L;
 	private static Logger logger = LoggerFactory.getLogger(PLT.class);
+	/**
+	 * Number of inner node of the trees
+	 */
 	transient protected int t = 0;	
 	protected Tree tree = null;
 	
+	/**
+	 * Order of the tree (k-ary).
+	 */
 	protected int k = 2;
 	protected String treeType = "Complete";
 	protected String treeFile = null;
@@ -46,6 +52,9 @@ public class PLT extends AbstractLearner {
 	transient protected FeatureHasher fh = null;
 	protected String hasher = "Universal";
 	protected int fhseed = 1;
+	/**
+	 * Hashed dimension, i.e. number of ML hashed features.
+	 */
 	protected int hd;
 	
 	protected double[] bias;

--- a/XMLC/src/Learner/PLT.java
+++ b/XMLC/src/Learner/PLT.java
@@ -32,7 +32,7 @@ public class PLT extends AbstractLearner {
 	private static final long serialVersionUID = 1L;
 	private static Logger logger = LoggerFactory.getLogger(PLT.class);
 	/**
-	 * Number of inner node of the trees
+	 * Number of node of the trees
 	 */
 	transient protected int t = 0;	
 	protected Tree tree = null;
@@ -150,7 +150,7 @@ public class PLT extends AbstractLearner {
 		this.t = this.tree.getSize(); 
 
 		logger.info( "#### Num. of labels: " + this.m + " Dim: " + this.d );
-		logger.info( "#### Num. of inner node of the trees: " + this.t  );
+		logger.info( "#### Num. of node of the trees: " + this.t  );
 		logger.info("#####################################################" );
 			
 		this.fh = FeatureHasherFactory.createFeatureHasher(this.hasher, fhseed, this.hd, this.t);
@@ -294,7 +294,17 @@ public class PLT extends AbstractLearner {
 		//logger.info("bias -> gradient, scalar, update: " + gradient + ", " + scalar +", " + update);
 	}
 	
-	
+	/**
+	 * Computes and returns {@code sigmoid(fh(x).dot(weight) + bias[label])}
+	 * 
+	 * @param x
+	 *            Sparse feature vector.
+	 * @param label
+	 *            Node index of PLT.
+	 * @return Class (1 or 0) probability estimate at node {@code label} for the
+	 *         given instance {@code x}, as per current weight vector and bias at
+	 *         node {@code label}.
+	 */
 	public double getPartialPosteriors(AVPair[] x, int label) {
 		double posterior = 0.0;
 		

--- a/XMLC/src/threshold/OfoFastThresholdTuner.java
+++ b/XMLC/src/threshold/OfoFastThresholdTuner.java
@@ -1,16 +1,18 @@
 package threshold;
 
 import java.util.Arrays;
-import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import util.Constants.ThresholdTuningDictKeys;
+import com.thoughtworks.xstream.mapper.Mapper.Null;
+
 import util.Constants.OFO;
+import util.Constants.ThresholdTuningDictKeys;
 
 /**
  * Tunes thresholds using online F-Measure optimization algorithm.
@@ -75,21 +77,23 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 	}
 
 	@Override
-	public double[] getTunedThresholds(Dictionary<String, Object> tuningData) {
+	public double[] getTunedThresholds(Map<String, Object> tuningData) {
 
-		@SuppressWarnings("unchecked")
-		List<HashSet<Integer>> predictedLabels = (List<HashSet<Integer>>) tuningData
-				.get(ThresholdTuningDictKeys.predictedLabels);
+		if (tuningData != null) {
+			@SuppressWarnings("unchecked")
+			List<HashSet<Integer>> predictedLabels = (List<HashSet<Integer>>) tuningData
+					.get(ThresholdTuningDictKeys.predictedLabels);
 
-		@SuppressWarnings("unchecked")
-		List<HashSet<Integer>> trueLabels = (List<HashSet<Integer>>) tuningData
-				.get(ThresholdTuningDictKeys.trueLabels);
+			@SuppressWarnings("unchecked")
+			List<HashSet<Integer>> trueLabels = (List<HashSet<Integer>>) tuningData
+					.get(ThresholdTuningDictKeys.trueLabels);
 
-		if (predictedLabels != null || trueLabels != null) {
+			if (predictedLabels != null || trueLabels != null) {
 
-			tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+				tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+			}
 		}
-
+		
 		double[] thresholds = new double[aThresholdNumerators.length];
 
 		for (int label = 0; label < aThresholdNumerators.length; label++) {
@@ -100,8 +104,10 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 	}
 
 	@Override
-	public HashMap<Integer, Double> getTunedThresholdsSparse(Dictionary<String, Object> tuningData) throws Exception {
-
+	public Map<Integer, Double> getTunedThresholdsSparse(Map<String, Object> tuningData) throws Exception {
+		
+		if(tuningData == null) throw new IllegalArgumentException("Incorrect tuning data");
+		
 		@SuppressWarnings("unchecked")
 		List<HashSet<Integer>> predictedLabels = (List<HashSet<Integer>>) tuningData
 				.get(ThresholdTuningDictKeys.predictedLabels);
@@ -111,7 +117,7 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 				.get(ThresholdTuningDictKeys.trueLabels);
 
 		if (predictedLabels == null || trueLabels == null)
-			throw new Exception("Missing true or predicted labels");
+			throw new IllegalArgumentException("Incorrect tuning data. Missing true or predicted labels");
 
 		HashSet<Integer> thresholdsToChange = tuneAndGetAffectedLabels(predictedLabels, trueLabels);
 		HashMap<Integer, Double> sparseThresholds = new HashMap<Integer, Double>();
@@ -149,7 +155,7 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 			for (int trueLabel : truePositives) {
 				bThresholdDenominators[trueLabel]++;
 				thresholdsToChange.add(trueLabel);
-				if (predictedLabels.contains(trueLabel))
+				if (predictedPositives.contains(trueLabel))
 					aThresholdNumerators[trueLabel]++;
 			}
 		}

--- a/XMLC/src/threshold/OfoFastThresholdTuner.java
+++ b/XMLC/src/threshold/OfoFastThresholdTuner.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import util.Constants.ThresholdTuningDictKeys;
+import util.Constants.OFO;
 
 /**
  * Tunes thresholds using online F-Measure optimization algorithm.
@@ -30,23 +31,30 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 		logger.info("#### OFO Fast");
 		logger.info("#### numberOfLabels: " + numberOfLabels);
 
-		if (thresholdTunerInitOption.aInit != null && thresholdTunerInitOption.aInit.length > 0
+		if (thresholdTunerInitOption != null && thresholdTunerInitOption.aInit != null
+				&& thresholdTunerInitOption.aInit.length > 0
 				&& thresholdTunerInitOption.bInit != null && thresholdTunerInitOption.bInit.length > 0) {
 
 			setaThresholdNumerators(thresholdTunerInitOption.aInit);
 			setbThresholdDenominatorst(thresholdTunerInitOption.bInit);
 			logger.info("#### a[] and b[] are initialized with predefined values");
 
-		} else if (thresholdTunerInitOption.aSeed != null && thresholdTunerInitOption.bSeed != null) {
+		} else {
 
 			aThresholdNumerators = new int[numberOfLabels];
 			bThresholdDenominators = new int[numberOfLabels];
 
-			Arrays.fill(aThresholdNumerators, thresholdTunerInitOption.aSeed);
-			Arrays.fill(bThresholdDenominators, thresholdTunerInitOption.bSeed);
+			int aSeed = thresholdTunerInitOption != null && thresholdTunerInitOption.aSeed != null
+					? thresholdTunerInitOption.aSeed : OFO.defaultaSeed;
 
-			logger.info("#### a[] seed: " + thresholdTunerInitOption.aSeed);
-			logger.info("#### b[] seed: " + thresholdTunerInitOption.bSeed);
+			int bSeed = thresholdTunerInitOption != null && thresholdTunerInitOption.bSeed != null
+					? thresholdTunerInitOption.bSeed : OFO.defaultbSeed;
+
+			Arrays.fill(aThresholdNumerators, aSeed);
+			Arrays.fill(bThresholdDenominators, bSeed);
+
+			logger.info("#### a[] seed: " + aSeed);
+			logger.info("#### b[] seed: " + bSeed);
 		}
 
 		logger.info("#####################################################");
@@ -92,7 +100,7 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 	}
 
 	@Override
-	HashMap<Integer, Double> getTunedThresholdsSparse(Dictionary<String, Object> tuningData) throws Exception {
+	public HashMap<Integer, Double> getTunedThresholdsSparse(Dictionary<String, Object> tuningData) throws Exception {
 
 		@SuppressWarnings("unchecked")
 		List<HashSet<Integer>> predictedLabels = (List<HashSet<Integer>>) tuningData
@@ -125,23 +133,72 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 	 */
 	private HashSet<Integer> tuneAndGetAffectedLabels(List<HashSet<Integer>> predictedLabels,
 			List<HashSet<Integer>> trueLabels) {
+
 		HashSet<Integer> thresholdsToChange = new HashSet<Integer>();
 
 		for (int j = 0; j < predictedLabels.size(); j++) {
 
 			HashSet<Integer> predictedPositives = predictedLabels.get(j);
-			HashSet<Integer> realPositives = trueLabels.get(j);
+			HashSet<Integer> truePositives = trueLabels.get(j);
 
 			for (int predictedLabel : predictedPositives) {
 				bThresholdDenominators[predictedLabel]++;
 				thresholdsToChange.add(predictedLabel);
 			}
 
-			for (int trueLabel : realPositives) {
+			for (int trueLabel : truePositives) {
 				bThresholdDenominators[trueLabel]++;
 				thresholdsToChange.add(trueLabel);
 				if (predictedLabels.contains(trueLabel))
 					aThresholdNumerators[trueLabel]++;
+			}
+		}
+
+		return thresholdsToChange;
+	}
+
+	/*
+	 * For single instance, this perform worse than tuneAndGetAffectedLabels,
+	 * how ever, for many instances, this performs better.
+	 * 
+	 * For single instance: 0.87 ms by tuneAndGetAffectedLabels1, and 0.34 ms by
+	 * tuneAndGetAffectedLabels (averaged over 1.0E8 iterations of random
+	 * instantiations)
+	 * 
+	 * For 10000 instances: 1.25 ms by tuneAndGetAffectedLabels1, and 73.17 ms
+	 * by tuneAndGetAffectedLabels (averaged over 1000 iterations of random
+	 * instantiations)
+	 * 
+	 * For 10 instances: 0.9 ms by tuneAndGetAffectedLabels1, and 0.37 ms by
+	 * tuneAndGetAffectedLabels (averaged over 1000000 iterations of random
+	 * instantiations)
+	 */
+	@SuppressWarnings("unused")
+	private HashSet<Integer> tuneAndGetAffectedLabels1(List<HashSet<Integer>> predictedLabels,
+			List<HashSet<Integer>> trueLabels) {
+
+		HashSet<Integer> thresholdsToChange = new HashSet<Integer>();
+
+		for (int j = 0; j < predictedLabels.size(); j++) {
+
+			HashSet<Integer> predictedPositives = predictedLabels.get(j);
+			HashSet<Integer> truePositives = trueLabels.get(j);
+
+			HashSet<Integer> intersection = new HashSet<Integer>(truePositives);
+			intersection.retainAll(predictedPositives);
+
+			HashSet<Integer> union = new HashSet<Integer>(truePositives);
+			union.addAll(predictedPositives);
+
+			for (int label : intersection) {
+				aThresholdNumerators[label]++;
+				bThresholdDenominators[label]++;
+				thresholdsToChange.add(label);
+			}
+
+			for (int label : union) {
+				bThresholdDenominators[label]++;
+				thresholdsToChange.add(label);
 			}
 		}
 

--- a/XMLC/src/threshold/OfoFastThresholdTuner.java
+++ b/XMLC/src/threshold/OfoFastThresholdTuner.java
@@ -9,10 +9,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.thoughtworks.xstream.mapper.Mapper.Null;
-
 import util.Constants.OFO;
-import util.Constants.ThresholdTuningDictKeys;
+import util.Constants.ThresholdTuningDataKeys;
 
 /**
  * Tunes thresholds using online F-Measure optimization algorithm.
@@ -77,23 +75,28 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 	}
 
 	@Override
+	public ThresholdTuners getTunerType() {
+		return ThresholdTuners.OfoFast;
+	}
+
+	@Override
 	public double[] getTunedThresholds(Map<String, Object> tuningData) {
 
 		if (tuningData != null) {
 			@SuppressWarnings("unchecked")
 			List<HashSet<Integer>> predictedLabels = (List<HashSet<Integer>>) tuningData
-					.get(ThresholdTuningDictKeys.predictedLabels);
+					.get(ThresholdTuningDataKeys.predictedLabels);
 
 			@SuppressWarnings("unchecked")
 			List<HashSet<Integer>> trueLabels = (List<HashSet<Integer>>) tuningData
-					.get(ThresholdTuningDictKeys.trueLabels);
+					.get(ThresholdTuningDataKeys.trueLabels);
 
 			if (predictedLabels != null || trueLabels != null) {
 
 				tuneAndGetAffectedLabels(predictedLabels, trueLabels);
 			}
 		}
-		
+
 		double[] thresholds = new double[aThresholdNumerators.length];
 
 		for (int label = 0; label < aThresholdNumerators.length; label++) {
@@ -105,16 +108,17 @@ public class OfoFastThresholdTuner extends ThresholdTuner {
 
 	@Override
 	public Map<Integer, Double> getTunedThresholdsSparse(Map<String, Object> tuningData) throws Exception {
-		
-		if(tuningData == null) throw new IllegalArgumentException("Incorrect tuning data");
-		
+
+		if (tuningData == null)
+			throw new IllegalArgumentException("Incorrect tuning data");
+
 		@SuppressWarnings("unchecked")
 		List<HashSet<Integer>> predictedLabels = (List<HashSet<Integer>>) tuningData
-				.get(ThresholdTuningDictKeys.predictedLabels);
+				.get(ThresholdTuningDataKeys.predictedLabels);
 
 		@SuppressWarnings("unchecked")
 		List<HashSet<Integer>> trueLabels = (List<HashSet<Integer>>) tuningData
-				.get(ThresholdTuningDictKeys.trueLabels);
+				.get(ThresholdTuningDataKeys.trueLabels);
 
 		if (predictedLabels == null || trueLabels == null)
 			throw new IllegalArgumentException("Incorrect tuning data. Missing true or predicted labels");

--- a/XMLC/src/threshold/OfoFastThresholdTuner.java
+++ b/XMLC/src/threshold/OfoFastThresholdTuner.java
@@ -1,0 +1,150 @@
+package threshold;
+
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import util.Constants.ThresholdTuningDictKeys;
+
+/**
+ * Tunes thresholds using online F-Measure optimization algorithm.
+ * 
+ * @author Sayan
+ *
+ */
+public class OfoFastThresholdTuner extends ThresholdTuner {
+	private static Logger logger = LoggerFactory.getLogger(OfoFastThresholdTuner.class);
+
+	protected int[] aThresholdNumerators = null;
+	protected int[] bThresholdDenominators = null;
+
+	public OfoFastThresholdTuner(int numberOfLabels, ThresholdTunerInitOption thresholdTunerInitOption) {
+		super(numberOfLabels, thresholdTunerInitOption);
+
+		logger.info("#####################################################");
+		logger.info("#### OFO Fast");
+		logger.info("#### numberOfLabels: " + numberOfLabels);
+
+		if (thresholdTunerInitOption.aInit != null && thresholdTunerInitOption.aInit.length > 0
+				&& thresholdTunerInitOption.bInit != null && thresholdTunerInitOption.bInit.length > 0) {
+
+			setaThresholdNumerators(thresholdTunerInitOption.aInit);
+			setbThresholdDenominatorst(thresholdTunerInitOption.bInit);
+			logger.info("#### a[] and b[] are initialized with predefined values");
+
+		} else if (thresholdTunerInitOption.aSeed != null && thresholdTunerInitOption.bSeed != null) {
+
+			aThresholdNumerators = new int[numberOfLabels];
+			bThresholdDenominators = new int[numberOfLabels];
+
+			Arrays.fill(aThresholdNumerators, thresholdTunerInitOption.aSeed);
+			Arrays.fill(bThresholdDenominators, thresholdTunerInitOption.bSeed);
+
+			logger.info("#### a[] seed: " + thresholdTunerInitOption.aSeed);
+			logger.info("#### b[] seed: " + thresholdTunerInitOption.bSeed);
+		}
+
+		logger.info("#####################################################");
+	}
+
+	private void setaThresholdNumerators(int[] aInit) {
+		if (aInit.length != numberOfLabels) {
+			System.exit(-1);
+		}
+		aThresholdNumerators = aInit;
+	}
+
+	private void setbThresholdDenominatorst(int[] bInit) {
+		if (bInit.length != numberOfLabels) {
+			System.exit(-1);
+		}
+		bThresholdDenominators = bInit;
+	}
+
+	@Override
+	public double[] getTunedThresholds(Dictionary<String, Object> tuningData) {
+
+		@SuppressWarnings("unchecked")
+		List<HashSet<Integer>> predictedLabels = (List<HashSet<Integer>>) tuningData
+				.get(ThresholdTuningDictKeys.predictedLabels);
+
+		@SuppressWarnings("unchecked")
+		List<HashSet<Integer>> trueLabels = (List<HashSet<Integer>>) tuningData
+				.get(ThresholdTuningDictKeys.trueLabels);
+
+		if (predictedLabels != null || trueLabels != null) {
+
+			tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+		}
+
+		double[] thresholds = new double[aThresholdNumerators.length];
+
+		for (int label = 0; label < aThresholdNumerators.length; label++) {
+			thresholds[label] = (double) aThresholdNumerators[label] / (double) bThresholdDenominators[label];
+		}
+
+		return thresholds;
+	}
+
+	@Override
+	HashMap<Integer, Double> getTunedThresholdsSparse(Dictionary<String, Object> tuningData) throws Exception {
+
+		@SuppressWarnings("unchecked")
+		List<HashSet<Integer>> predictedLabels = (List<HashSet<Integer>>) tuningData
+				.get(ThresholdTuningDictKeys.predictedLabels);
+
+		@SuppressWarnings("unchecked")
+		List<HashSet<Integer>> trueLabels = (List<HashSet<Integer>>) tuningData
+				.get(ThresholdTuningDictKeys.trueLabels);
+
+		if (predictedLabels == null || trueLabels == null)
+			throw new Exception("Missing true or predicted labels");
+
+		HashSet<Integer> thresholdsToChange = tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+		HashMap<Integer, Double> sparseThresholds = new HashMap<Integer, Double>();
+
+		for (int label : thresholdsToChange) {
+			sparseThresholds.put(label, (double) aThresholdNumerators[label] / (double) bThresholdDenominators[label]);
+		}
+
+		return sparseThresholds;
+	}
+
+	/**
+	 * Tunes and returns the set of labels for which thresholds need to be
+	 * changed.
+	 * 
+	 * @param predictedLabels
+	 * @param trueLabels
+	 * @return Set of labels for which thresholds need to be changed.
+	 */
+	private HashSet<Integer> tuneAndGetAffectedLabels(List<HashSet<Integer>> predictedLabels,
+			List<HashSet<Integer>> trueLabels) {
+		HashSet<Integer> thresholdsToChange = new HashSet<Integer>();
+
+		for (int j = 0; j < predictedLabels.size(); j++) {
+
+			HashSet<Integer> predictedPositives = predictedLabels.get(j);
+			HashSet<Integer> realPositives = trueLabels.get(j);
+
+			for (int predictedLabel : predictedPositives) {
+				bThresholdDenominators[predictedLabel]++;
+				thresholdsToChange.add(predictedLabel);
+			}
+
+			for (int trueLabel : realPositives) {
+				bThresholdDenominators[trueLabel]++;
+				thresholdsToChange.add(trueLabel);
+				if (predictedLabels.contains(trueLabel))
+					aThresholdNumerators[trueLabel]++;
+			}
+		}
+
+		return thresholdsToChange;
+	}
+}

--- a/XMLC/src/threshold/ThresholdTuner.java
+++ b/XMLC/src/threshold/ThresholdTuner.java
@@ -1,7 +1,6 @@
 package threshold;
 
-import java.util.Dictionary;
-import java.util.HashMap;
+import java.util.Map;
 
 import util.Constants;
 
@@ -29,7 +28,7 @@ public abstract class ThresholdTuner {
 	 *            {@link Constants.ThresholdTuningDictKeys}.
 	 * @return Tuned threshold array.
 	 */
-	abstract double[] getTunedThresholds(Dictionary<String, Object> tuningData);
+	abstract double[] getTunedThresholds(Map<String, Object> tuningData);
 
 	/**
 	 * Tunes thresholds as per the {@code tuningData}
@@ -43,6 +42,6 @@ public abstract class ThresholdTuner {
 	 *         value for threshold.
 	 * @throws Exception
 	 */
-	abstract HashMap<Integer, Double> getTunedThresholdsSparse(Dictionary<String, Object> tuningData)
+	abstract Map<Integer, Double> getTunedThresholdsSparse(Map<String, Object> tuningData)
 			throws Exception;
 }

--- a/XMLC/src/threshold/ThresholdTuner.java
+++ b/XMLC/src/threshold/ThresholdTuner.java
@@ -13,6 +13,8 @@ import util.Constants;
  */
 public abstract class ThresholdTuner {
 	protected final int numberOfLabels;
+	
+	public abstract ThresholdTuners getTunerType();
 
 	public ThresholdTuner(int numberOfLabels, ThresholdTunerInitOption thresholdTunerInitOption) {
 		this.numberOfLabels = numberOfLabels;
@@ -25,10 +27,10 @@ public abstract class ThresholdTuner {
 	 *            Data required to tune thresholds such as realLabels,
 	 *            predictedLabels, probability estimates etc. Keys in the
 	 *            dictionary ideally should be from
-	 *            {@link Constants.ThresholdTuningDictKeys}.
+	 *            {@link Constants.ThresholdTuningDataKeys}.
 	 * @return Tuned threshold array.
 	 */
-	abstract double[] getTunedThresholds(Map<String, Object> tuningData);
+	public abstract double[] getTunedThresholds(Map<String, Object> tuningData);
 
 	/**
 	 * Tunes thresholds as per the {@code tuningData}
@@ -37,11 +39,11 @@ public abstract class ThresholdTuner {
 	 *            Data required to tune thresholds such as realLabels,
 	 *            predictedLabels, probability estimates etc. Keys in the
 	 *            dictionary ideally should be from
-	 *            {@link Constants.ThresholdTuningDictKeys}.
+	 *            {@link Constants.ThresholdTuningDataKeys}.
 	 * @return Sparse tuned thresholds, the key is label, and the value is new
 	 *         value for threshold.
 	 * @throws Exception
 	 */
-	abstract Map<Integer, Double> getTunedThresholdsSparse(Map<String, Object> tuningData)
+	public abstract Map<Integer, Double> getTunedThresholdsSparse(Map<String, Object> tuningData)
 			throws Exception;
 }

--- a/XMLC/src/threshold/ThresholdTuner.java
+++ b/XMLC/src/threshold/ThresholdTuner.java
@@ -1,0 +1,48 @@
+package threshold;
+
+import java.util.Dictionary;
+import java.util.HashMap;
+
+import util.Constants;
+
+/**
+ * Provides an interface to the Tuners. Tuners can be injected to learners,
+ * where threshold tuning is an integral part of training.
+ * 
+ * @author Sayan
+ *
+ */
+public abstract class ThresholdTuner {
+	protected final int numberOfLabels;
+
+	public ThresholdTuner(int numberOfLabels, ThresholdTunerInitOption thresholdTunerInitOption) {
+		this.numberOfLabels = numberOfLabels;
+	}
+
+	/**
+	 * Tunes thresholds as per the {@code tuningData}
+	 * 
+	 * @param tuningData
+	 *            Data required to tune thresholds such as realLabels,
+	 *            predictedLabels, probability estimates etc. Keys in the
+	 *            dictionary ideally should be from
+	 *            {@link Constants.ThresholdTuningDictKeys}.
+	 * @return Tuned threshold array.
+	 */
+	abstract double[] getTunedThresholds(Dictionary<String, Object> tuningData);
+
+	/**
+	 * Tunes thresholds as per the {@code tuningData}
+	 * 
+	 * @param tuningData
+	 *            Data required to tune thresholds such as realLabels,
+	 *            predictedLabels, probability estimates etc. Keys in the
+	 *            dictionary ideally should be from
+	 *            {@link Constants.ThresholdTuningDictKeys}.
+	 * @return Sparse tuned thresholds, the key is label, and the value is new
+	 *         value for threshold.
+	 * @throws Exception
+	 */
+	abstract HashMap<Integer, Double> getTunedThresholdsSparse(Dictionary<String, Object> tuningData)
+			throws Exception;
+}

--- a/XMLC/src/threshold/ThresholdTunerFactory.java
+++ b/XMLC/src/threshold/ThresholdTunerFactory.java
@@ -1,0 +1,29 @@
+package threshold;
+
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class ThresholdTunerFactory {
+	private static Logger logger = LoggerFactory.getLogger(ThresholdTunerFactory.class);
+
+	public static ThresholdTuner createThresholdTuner(int numberOfLabels, Properties properties) {
+
+		ThresholdTuners type = (ThresholdTuners) properties.get("tunerType");
+		ThresholdTunerInitOption initOption = (ThresholdTunerInitOption) properties.get("tunerInitOption");
+		ThresholdTuner retVal = null;
+
+		switch (type) {
+		case OfoFast:
+			retVal = new OfoFastThresholdTuner(numberOfLabels, initOption);
+			break;
+
+		default:
+			logger.info("ThresholdTuner implementation for " + type + " is not yet implmented.");
+			break;
+		}
+
+		return retVal;
+	}
+}

--- a/XMLC/src/threshold/ThresholdTunerInitOption.java
+++ b/XMLC/src/threshold/ThresholdTunerInitOption.java
@@ -1,0 +1,27 @@
+package threshold;
+
+/**
+ * Provides a set of optional properties that are needed to initialize an
+ * instance of {@link ThresholdTuner}
+ * 
+ * @author Sayan
+ *
+ */
+public class ThresholdTunerInitOption {
+	/**
+	 * Single seed value for aThresholdNumerators (OFO).
+	 */
+	public Integer aSeed;
+	/**
+	 * Single seed value for bThresholdDenominators (OFO).
+	 */
+	public Integer bSeed;
+	/**
+	 * Initial preset value for aThresholdNumerators (OFO).
+	 */
+	public int[] aInit;
+	/**
+	 * Initial preset value for bThresholdDenominators (OFO).
+	 */
+	public int[] bInit;
+}

--- a/XMLC/src/threshold/ThresholdTuners.java
+++ b/XMLC/src/threshold/ThresholdTuners.java
@@ -1,0 +1,5 @@
+package threshold;
+
+public enum ThresholdTuners {
+	Eum, EumFast, Exu, ExuFast, Ofo, OfoFast
+}

--- a/XMLC/src/util/Constants.java
+++ b/XMLC/src/util/Constants.java
@@ -1,0 +1,21 @@
+package util;
+
+/**
+ * Contains all constant values (magic strings) used in this library
+ * 
+ * @author Sayan
+ *
+ */
+public class Constants {
+	/**
+	 * Contains constant string literals for the dictionary keys used for
+	 * threshold tuning.
+	 * 
+	 * @author Sayan
+	 *
+	 */
+	public static class ThresholdTuningDictKeys {
+		public static final String trueLabels = "trueLabels";
+		public static final String predictedLabels = "predictedLabels";
+	}
+}

--- a/XMLC/src/util/Constants.java
+++ b/XMLC/src/util/Constants.java
@@ -18,4 +18,9 @@ public class Constants {
 		public static final String trueLabels = "trueLabels";
 		public static final String predictedLabels = "predictedLabels";
 	}
+	
+	public static class OFO {
+		public static final int defaultaSeed = 1;
+		public static final int defaultbSeed = 100;
+	}
 }

--- a/XMLC/src/util/Constants.java
+++ b/XMLC/src/util/Constants.java
@@ -14,7 +14,7 @@ public class Constants {
 	 * @author Sayan
 	 *
 	 */
-	public static class ThresholdTuningDictKeys {
+	public static class ThresholdTuningDataKeys {
 		public static final String trueLabels = "trueLabels";
 		public static final String predictedLabels = "predictedLabels";
 	}

--- a/XMLC/tests/threshold/OfoFastThresholdTunerTests.java
+++ b/XMLC/tests/threshold/OfoFastThresholdTunerTests.java
@@ -329,8 +329,8 @@ public class OfoFastThresholdTunerTests {
 		};
 		Map<String, Object> tuningData = new HashMap<String, Object>() {
 			{
-				put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
-				put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+				put(Constants.ThresholdTuningDataKeys.trueLabels, trueLabels);
+				put(Constants.ThresholdTuningDataKeys.predictedLabels, predictedLabels);
 			}
 		};
 		double[] expected = { 3.0 / 80.0, 4.0 / 82.0, 4.0 / 82.0, 4.0 / 82.0, 3.0 / 80.0, 3.0 / 80.0, 3.0 / 80.0,
@@ -372,8 +372,8 @@ public class OfoFastThresholdTunerTests {
 		};
 		Map<String, Object> tuningData = new HashMap<String, Object>() {
 			{
-				put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
-				put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+				put(Constants.ThresholdTuningDataKeys.trueLabels, trueLabels);
+				put(Constants.ThresholdTuningDataKeys.predictedLabels, predictedLabels);
 			}
 		};
 		double[] expected = { 3.0 / 81.0, 4.0 / 83.0, 5.0 / 84.0, 5.0 / 84.0, 3.0 / 80.0, 4.0 / 82.0, 3.0 / 81.0,
@@ -393,6 +393,7 @@ public class OfoFastThresholdTunerTests {
 
 	}
 
+	@SuppressWarnings("serial")
 	@Test(expected = IllegalArgumentException.class)
 	public void getTunedThresholdsSparse_ThrowsException_InAbsenceOfPredictedLabels() throws Exception {
 
@@ -406,7 +407,7 @@ public class OfoFastThresholdTunerTests {
 		};
 		Map<String, Object> tuningData = new HashMap<String, Object>() {
 			{
-				put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
+				put(Constants.ThresholdTuningDataKeys.trueLabels, trueLabels);
 			}
 		};
 
@@ -414,6 +415,7 @@ public class OfoFastThresholdTunerTests {
 		target.getTunedThresholdsSparse(tuningData);
 	}
 
+	@SuppressWarnings("serial")
 	@Test(expected = IllegalArgumentException.class)
 	public void getTunedThresholdsSparse_ThrowsException_InAbsenceOfTrueLabels() throws Exception {
 
@@ -427,7 +429,7 @@ public class OfoFastThresholdTunerTests {
 		};
 		Map<String, Object> tuningData = new HashMap<String, Object>() {
 			{
-				put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+				put(Constants.ThresholdTuningDataKeys.predictedLabels, predictedLabels);
 			}
 		};
 
@@ -435,6 +437,7 @@ public class OfoFastThresholdTunerTests {
 		target.getTunedThresholdsSparse(tuningData);
 	}
 
+	@SuppressWarnings("serial")
 	@Test
 	public void getTunedThresholdsSparse_ReturnsCorrectLabels() throws Exception {
 
@@ -455,11 +458,11 @@ public class OfoFastThresholdTunerTests {
 		};
 		Map<String, Object> tuningData = new HashMap<String, Object>() {
 			{
-				put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
-				put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+				put(Constants.ThresholdTuningDataKeys.trueLabels, trueLabels);
+				put(Constants.ThresholdTuningDataKeys.predictedLabels, predictedLabels);
 			}
 		};
-		Set<Integer> expected = new HashSet(Arrays.asList(0, 1, 2, 3, 5, 6, 7, 8, 9));
+		Set<Integer> expected = new HashSet<Integer>(Arrays.asList(0, 1, 2, 3, 5, 6, 7, 8, 9));
 
 		// act
 		Map<Integer, Double> sparseThresholds = target.getTunedThresholdsSparse(tuningData);
@@ -483,8 +486,8 @@ public class OfoFastThresholdTunerTests {
 		}
 
 		Map<String, Object> tuningData = new HashMap<String, Object>();
-		tuningData.put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
-		tuningData.put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+		tuningData.put(Constants.ThresholdTuningDataKeys.trueLabels, trueLabels);
+		tuningData.put(Constants.ThresholdTuningDataKeys.predictedLabels, predictedLabels);
 		Set<Integer> expected = new HashSet<Integer>();
 		for (HashSet<Integer> labels : trueLabels) {
 			expected.addAll(labels);

--- a/XMLC/tests/threshold/OfoFastThresholdTunerTests.java
+++ b/XMLC/tests/threshold/OfoFastThresholdTunerTests.java
@@ -4,23 +4,33 @@ import static org.junit.Assert.*;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import util.Constants;
+
 public class OfoFastThresholdTunerTests {
 	OfoFastThresholdTuner target;
-	int numberOfLabels = 50000;
-	int maximumNumberOfLabelsPerInstance = 5;
+	final int totalNumberOfLabels = 50000;
+	final int maximumNumberOfLabelsPerInstance = 5;
 	private static DecimalFormat df2 = new DecimalFormat(".##");
 
 	@Before
 	public void arrange() {
-		target = new OfoFastThresholdTuner(numberOfLabels, null);
+		target = new OfoFastThresholdTuner(totalNumberOfLabels, null);
 	}
 
 	@After
@@ -29,6 +39,10 @@ public class OfoFastThresholdTunerTests {
 	}
 
 	private List<Integer> getRandomInts() {
+		return getRandomInts(maximumNumberOfLabelsPerInstance, totalNumberOfLabels);
+	}
+
+	private List<Integer> getRandomInts(int maximumNumberOfLabelsPerInstance, int totalNumberOfLabels) {
 
 		int numberOfLabels = ThreadLocalRandom.current()
 				.nextInt(1, maximumNumberOfLabelsPerInstance + 1);
@@ -37,93 +51,429 @@ public class OfoFastThresholdTunerTests {
 
 		for (int i = 0; i < numberOfLabels; i++)
 			retVal.add(ThreadLocalRandom.current()
-					.nextInt(numberOfLabels));
+					.nextInt(totalNumberOfLabels));
 
 		return retVal;
 	}
 
-	// START performance tests
-	// To run below tests on performance benchmark on tuneAndGetAffectedLabels and tuneAndGetAffectedLabels1,
-	// change the access modifiers of those.
-/*
+	// START benchmark tests
+	/*
+	 * // To run below tests on performance benchmark on
+	 * tuneAndGetAffectedLabels // and tuneAndGetAffectedLabels1, // change the
+	 * access modifiers of those.
+	 * 
+	 * @Test public void
+	 * performanceComparisonBetweenSetBasedTuningAndOriginal_SingleInstances() {
+	 * // Arrange int numberOfInstances = 1; double iteration = 100000000;
+	 * double elapsed1 = 0, elapsed2 = 0;
+	 * 
+	 * for (int k = 0; k < iteration; k++) { List<HashSet<Integer>> trueLabels =
+	 * new ArrayList<HashSet<Integer>>(); List<HashSet<Integer>> predictedLabels
+	 * = new ArrayList<HashSet<Integer>>();
+	 * 
+	 * for (int i = 0; i < numberOfInstances; i++) { trueLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); predictedLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); }
+	 * 
+	 * // act
+	 * 
+	 * long startTime1 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels(predictedLabels, trueLabels); elapsed1 +=
+	 * (double) (System.nanoTime() - startTime1) / iteration;
+	 * 
+	 * long startTime2 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels); elapsed2
+	 * += (double) (System.nanoTime() - startTime2) / iteration; }
+	 * 
+	 * // Assert System.out.println("Average (over " + iteration +
+	 * " iterations) time taken for " + numberOfInstances +
+	 * " instances by the original method : " + df2.format(elapsed1 / (1000.0 *
+	 * numberOfInstances)) + " ms."); System.out.println("Average  (over " +
+	 * iteration + " iterations) time taken for " + numberOfInstances +
+	 * " instances by the set based  method : " + df2.format(elapsed2 / (1000.0
+	 * * numberOfInstances)) + " ms."); assert (true);// nothing to assert }
+	 * 
+	 * @Test public void
+	 * performanceComparisonBetweenSetBasedTuningAndOriginal_NumberOfInstances10
+	 * () { // Arrange int numberOfInstances = 10; double iteration = 1000000;
+	 * double elapsed1 = 0, elapsed2 = 0; for (int k = 0; k < iteration; k++) {
+	 * List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+	 * List<HashSet<Integer>> predictedLabels = new
+	 * ArrayList<HashSet<Integer>>();
+	 * 
+	 * for (int i = 0; i < numberOfInstances; i++) { trueLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); predictedLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); }
+	 * 
+	 * // act
+	 * 
+	 * long startTime1 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels(predictedLabels, trueLabels); elapsed1 +=
+	 * (double) (System.nanoTime() - startTime1) / iteration;
+	 * 
+	 * long startTime2 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels); elapsed2
+	 * += (double) (System.nanoTime() - startTime2) / iteration; } // Assert
+	 * System.out.println("Average (over " + iteration +
+	 * " iterations) time taken for " + numberOfInstances +
+	 * " instances by the original method : " + df2.format(elapsed1 / (1000.0 *
+	 * numberOfInstances)) + " ms."); System.out.println("Average  (over " +
+	 * iteration + " iterations) time taken for " + numberOfInstances +
+	 * " instances by the set based  method : " + df2.format(elapsed2 / (1000.0
+	 * * numberOfInstances)) + " ms."); assert (true);// nothing to assert }
+	 * 
+	 * @Test public void
+	 * performanceComparisonBetweenSetBasedTuningAndOriginal_NumberOfInstances100
+	 * () { // Arrange int numberOfInstances = 100; double iteration = 100;
+	 * 
+	 * List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+	 * List<HashSet<Integer>> predictedLabels = new
+	 * ArrayList<HashSet<Integer>>();
+	 * 
+	 * for (int i = 0; i < numberOfInstances; i++) { trueLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); predictedLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); }
+	 * 
+	 * // act double elapsed1 = 0, elapsed2 = 0; for (int i = 0; i < iteration;
+	 * i++) { long startTime1 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels(predictedLabels, trueLabels); elapsed1 +=
+	 * (double) (System.nanoTime() - startTime1) / iteration;
+	 * 
+	 * long startTime2 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels); elapsed2
+	 * += (double) (System.nanoTime() - startTime2) / iteration; } // Assert
+	 * System.out.println("Average (over " + iteration +
+	 * " iterations) time taken for " + numberOfInstances +
+	 * " instances by the original method : " + df2.format(elapsed1 / (1000.0 *
+	 * numberOfInstances)) + " ms."); System.out.println("Average  (over " +
+	 * iteration + " iterations) time taken for " + numberOfInstances +
+	 * " instances by the set based  method : " + df2.format(elapsed2 / (1000.0
+	 * * numberOfInstances)) + " ms."); assert (true);// nothing to assert }
+	 * 
+	 * @Test public void
+	 * performanceComparisonBetweenSetBasedTuningAndOriginal_NumberOfInstances1K
+	 * () { // Arrange int numberOfInstances = 1000; double iteration = 100;
+	 * double elapsed1 = 0, elapsed2 = 0; for (int k = 0; k < iteration; k++) {
+	 * List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+	 * List<HashSet<Integer>> predictedLabels = new
+	 * ArrayList<HashSet<Integer>>();
+	 * 
+	 * for (int i = 0; i < numberOfInstances; i++) { trueLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); predictedLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); }
+	 * 
+	 * // act
+	 * 
+	 * long startTime1 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels(predictedLabels, trueLabels); elapsed1 +=
+	 * (double) (System.nanoTime() - startTime1) / iteration;
+	 * 
+	 * long startTime2 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels); elapsed2
+	 * += (double) (System.nanoTime() - startTime2) / iteration; } // Assert
+	 * System.out.println("Average (over " + iteration +
+	 * " iterations) time taken for " + numberOfInstances +
+	 * " instances by the original method : " + df2.format(elapsed1 / (1000.0 *
+	 * numberOfInstances)) + " ms."); System.out.println("Average  (over " +
+	 * iteration + " iterations) time taken for " + numberOfInstances +
+	 * " instances by the set based  method : " + df2.format(elapsed2 / (1000.0
+	 * * numberOfInstances)) + " ms."); assert (true);// nothing to assert }
+	 * 
+	 * @Test public void
+	 * performanceComparisonBetweenSetBasedTuningAndOriginal_NumberOfInstances10K
+	 * () { // Arrange int numberOfInstances = 10000; double iteration = 1000;
+	 * double elapsed1 = 0, elapsed2 = 0; for (int k = 0; k < iteration; k++) {
+	 * List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+	 * List<HashSet<Integer>> predictedLabels = new
+	 * ArrayList<HashSet<Integer>>();
+	 * 
+	 * for (int i = 0; i < numberOfInstances; i++) { trueLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); predictedLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); }
+	 * 
+	 * // act
+	 * 
+	 * long startTime1 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels(predictedLabels, trueLabels); elapsed1 +=
+	 * (double) (System.nanoTime() - startTime1) / iteration;
+	 * 
+	 * long startTime2 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels); elapsed2
+	 * += (double) (System.nanoTime() - startTime2) / iteration; } // Assert
+	 * System.out.println("Average (over " + iteration +
+	 * " iterations) time taken for " + numberOfInstances +
+	 * " instances by the original method : " + df2.format(elapsed1 / (1000.0 *
+	 * numberOfInstances)) + " ms."); System.out.println("Average  (over " +
+	 * iteration + " iterations) time taken for " + numberOfInstances +
+	 * " instances by the set based  method : " + df2.format(elapsed2 / (1000.0
+	 * * numberOfInstances)) + " ms."); assert (true);// nothing to assert }
+	 * 
+	 * // @Test public void
+	 * performanceComparisonBetweenSetBasedTuningAndOriginal_NumberOfInstances100k
+	 * () { // Arrange int numberOfInstances = 100000; double iteration = 100;
+	 * double elapsed1 = 0, elapsed2 = 0; for (int k = 0; k < iteration; k++) {
+	 * List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+	 * List<HashSet<Integer>> predictedLabels = new
+	 * ArrayList<HashSet<Integer>>();
+	 * 
+	 * for (int i = 0; i < numberOfInstances; i++) { trueLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); predictedLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); }
+	 * 
+	 * // act
+	 * 
+	 * long startTime1 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels(predictedLabels, trueLabels); elapsed1 +=
+	 * (double) (System.nanoTime() - startTime1) / iteration;
+	 * 
+	 * long startTime2 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels); elapsed2
+	 * += (double) (System.nanoTime() - startTime2) / iteration; } // Assert
+	 * System.out.println("Average (over " + iteration +
+	 * " iterations) time taken for " + numberOfInstances +
+	 * " instances by the original method : " + df2.format(elapsed1 / (1000.0 *
+	 * numberOfInstances)) + " ms."); System.out.println("Average  (over " +
+	 * iteration + " iterations) time taken for " + numberOfInstances +
+	 * " instances by the set based  method : " + df2.format(elapsed2 / (1000.0
+	 * * numberOfInstances)) + " ms."); assert (true);// nothing to assert }
+	 * 
+	 * // @Test public void
+	 * performanceComparisonBetweenSetBasedTuningAndOriginal_NumberOfInstances1M
+	 * () { // Arrange int numberOfInstances = 1000000; double iteration = 100;
+	 * 
+	 * List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+	 * List<HashSet<Integer>> predictedLabels = new
+	 * ArrayList<HashSet<Integer>>();
+	 * 
+	 * for (int i = 0; i < numberOfInstances; i++) { trueLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); predictedLabels.add(new
+	 * HashSet<Integer>(getRandomInts())); }
+	 * 
+	 * // act double elapsed1 = 0, elapsed2 = 0; for (int i = 0; i < iteration;
+	 * i++) { long startTime1 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels(predictedLabels, trueLabels); elapsed1 +=
+	 * (double) (System.nanoTime() - startTime1) / iteration;
+	 * 
+	 * long startTime2 = System.nanoTime();
+	 * target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels); elapsed2
+	 * += (double) (System.nanoTime() - startTime2) / iteration; } // Assert
+	 * System.out.println("Average (over " + iteration +
+	 * " iterations) time taken for " + numberOfInstances +
+	 * " instances by the original method : " + df2.format(elapsed1 / (1000.0 *
+	 * numberOfInstances)) + " ms."); System.out.println("Average  (over " +
+	 * iteration + " iterations) time taken for " + numberOfInstances +
+	 * " instances by the set based  method : " + df2.format(elapsed2 / (1000.0
+	 * * numberOfInstances)) + " ms."); assert (true);// nothing to assert }
+	 */
+	// END benchmark tests
+
 	@Test
-	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_SingleInstances() {
+	public void getTunedThresholds_ReturnsValue_EvenInAbsenceOfTuningData() {
 		// Arrange
-		int numberOfInstances = 1;
-		double iteration = 100000000;
-		double elapsed1 = 0, elapsed2 = 0;
+		int totalNumberOfLabels = 10;
+		target = new OfoFastThresholdTuner(totalNumberOfLabels, null);
+		double[] expected = new double[totalNumberOfLabels];
+		Arrays.fill(expected, (1 / 100.0));
 
-		for (int k = 0; k < iteration; k++) {
-			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
-			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
-
-			for (int i = 0; i < numberOfInstances; i++) {
-				trueLabels.add(new HashSet<Integer>(getRandomInts()));
-				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
-			}
-
-			// act
-
-			long startTime1 = System.nanoTime();
-			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
-			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
-
-			long startTime2 = System.nanoTime();
-			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
-			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
-		}
+		// act
+		double[] actual = target.getTunedThresholds(null);
 
 		// Assert
-		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the original method : "
-				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
-		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the set based  method : "
-				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
-		assert (true);// nothing to assert
+		assertArrayEquals(expected, actual, 0.0001);
 	}
 
 	@Test
-	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances10() {
+	public void getTunedThresholds_ReturnsValueAsPerSeedValue_EvenInAbsenceOfTuningData() {
 		// Arrange
-		int numberOfInstances = 10;
-		double iteration = 1000000;
-		double elapsed1 = 0, elapsed2 = 0;
-		for (int k = 0; k < iteration; k++) {
-			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
-			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
-
-			for (int i = 0; i < numberOfInstances; i++) {
-				trueLabels.add(new HashSet<Integer>(getRandomInts()));
-				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+		int totalNumberOfLabels = 10;
+		ThresholdTunerInitOption options = new ThresholdTunerInitOption() {
+			{
+				aSeed = 3;
 			}
+		};
+		target = new OfoFastThresholdTuner(totalNumberOfLabels, options);
+		double[] expected = new double[totalNumberOfLabels];
+		Arrays.fill(expected, (3 / 100.0));
 
-			// act
+		// act
+		double[] actual = target.getTunedThresholds(null);
 
-			long startTime1 = System.nanoTime();
-			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
-			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
-
-			long startTime2 = System.nanoTime();
-			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
-			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
-		}
 		// Assert
-		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the original method : "
-				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
-		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the set based  method : "
-				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
-		assert (true);// nothing to assert
+		assertArrayEquals(expected, actual, 0.0001);
+	}
+
+	@SuppressWarnings("serial")
+	@Test
+	public void getTunedThresholds_TrueAndPredictedLabelSetAreSame_ReturnsCorrectValue() {
+		// Arrange
+		int totalNumberOfLabels = 10;
+		ThresholdTunerInitOption options = new ThresholdTunerInitOption() {
+			{
+				aSeed = 3;
+				bSeed = 80;
+			}
+		};
+		target = new OfoFastThresholdTuner(totalNumberOfLabels, options);
+
+		final List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>() {
+			{
+				add(new HashSet<Integer>(Arrays.asList(1, 2, 3)));
+				// add(new HashSet<Integer>(Arrays.asList(2, 3, 5, 8, 9)));
+			}
+		};
+		final List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>() {
+			{
+				add(new HashSet<Integer>(Arrays.asList(1, 2, 3)));
+				// add(new HashSet<Integer>(Arrays.asList(0, 2, 3, 5, 8)));
+			}
+		};
+		Map<String, Object> tuningData = new HashMap<String, Object>() {
+			{
+				put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
+				put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+			}
+		};
+		double[] expected = { 3.0 / 80.0, 4.0 / 82.0, 4.0 / 82.0, 4.0 / 82.0, 3.0 / 80.0, 3.0 / 80.0, 3.0 / 80.0,
+				3.0 / 80.0, 3.0 / 80.0, 3.0 / 80.0 };
+
+		// act
+		double[] actual = target.getTunedThresholds(tuningData);
+
+		// Assert
+		assertArrayEquals(expected, actual, 0.0001);
+	}
+
+	@SuppressWarnings("serial")
+	@Test
+	public void getTunedThresholds_TrueAndPredictedLabelSetAreNotSame_ReturnsCorrectValue() {
+		// Arrange
+		int totalNumberOfLabels = 10;
+		ThresholdTunerInitOption options = new ThresholdTunerInitOption() {
+			{
+				aSeed = 3;
+				bSeed = 80;
+			}
+		};
+		target = new OfoFastThresholdTuner(totalNumberOfLabels, options);
+
+		final List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>() {
+			{
+				add(new HashSet<Integer>(Arrays.asList(1, 2, 3)));
+				add(new HashSet<Integer>(Arrays.asList(2, 3, 5, 8, 9)));
+				add(new HashSet<Integer>(Arrays.asList(7, 8)));
+			}
+		};
+		final List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>() {
+			{
+				add(new HashSet<Integer>(Arrays.asList(1, 2, 3)));
+				add(new HashSet<Integer>(Arrays.asList(0, 2, 3, 5, 8)));
+				add(new HashSet<Integer>(Arrays.asList(1, 6, 9)));
+			}
+		};
+		Map<String, Object> tuningData = new HashMap<String, Object>() {
+			{
+				put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
+				put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+			}
+		};
+		double[] expected = { 3.0 / 81.0, 4.0 / 83.0, 5.0 / 84.0, 5.0 / 84.0, 3.0 / 80.0, 4.0 / 82.0, 3.0 / 81.0,
+				3.0 / 81.0, 4.0 / 83.0, 3.0 / 82.0 };
+
+		// act
+		double[] actual = target.getTunedThresholds(tuningData);
+
+		// Assert
+		assertArrayEquals(expected, actual, 0.0001);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getTunedThresholdsSparse_ThrowsException_InAbsenceOfTuningData() throws Exception {
+
+		target.getTunedThresholdsSparse(null);
+
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getTunedThresholdsSparse_ThrowsException_InAbsenceOfPredictedLabels() throws Exception {
+
+		// arrange
+		final List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>() {
+			{
+				add(new HashSet<Integer>(Arrays.asList(1, 2, 3)));
+				add(new HashSet<Integer>(Arrays.asList(2, 3, 5, 8, 9)));
+				add(new HashSet<Integer>(Arrays.asList(7, 8)));
+			}
+		};
+		Map<String, Object> tuningData = new HashMap<String, Object>() {
+			{
+				put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
+			}
+		};
+
+		// act
+		target.getTunedThresholdsSparse(tuningData);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getTunedThresholdsSparse_ThrowsException_InAbsenceOfTrueLabels() throws Exception {
+
+		// arrange
+		final List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>() {
+			{
+				add(new HashSet<Integer>(Arrays.asList(1, 2, 3)));
+				add(new HashSet<Integer>(Arrays.asList(0, 2, 3, 5, 8)));
+				add(new HashSet<Integer>(Arrays.asList(1, 6, 9)));
+			}
+		};
+		Map<String, Object> tuningData = new HashMap<String, Object>() {
+			{
+				put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+			}
+		};
+
+		// act
+		target.getTunedThresholdsSparse(tuningData);
 	}
 
 	@Test
-	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances100() {
-		// Arrange
+	public void getTunedThresholdsSparse_ReturnsCorrectLabels() throws Exception {
+
+		// arrange
+		final List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>() {
+			{
+				add(new HashSet<Integer>(Arrays.asList(1, 2, 3)));
+				add(new HashSet<Integer>(Arrays.asList(2, 3, 5, 8, 9)));
+				add(new HashSet<Integer>(Arrays.asList(7, 8)));
+			}
+		};
+		final List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>() {
+			{
+				add(new HashSet<Integer>(Arrays.asList(1, 2, 3)));
+				add(new HashSet<Integer>(Arrays.asList(0, 2, 3, 5, 8)));
+				add(new HashSet<Integer>(Arrays.asList(1, 6, 9)));
+			}
+		};
+		Map<String, Object> tuningData = new HashMap<String, Object>() {
+			{
+				put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
+				put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+			}
+		};
+		Set<Integer> expected = new HashSet(Arrays.asList(0, 1, 2, 3, 5, 6, 7, 8, 9));
+
+		// act
+		Map<Integer, Double> sparseThresholds = target.getTunedThresholdsSparse(tuningData);
+		Set<Integer> actual = sparseThresholds.keySet();
+
+		// assert
+		assertTrue(expected.equals(actual));
+	}
+
+	@Test
+	public void getTunedThresholdsSparse_ReturnsCorrectLabels_For100RandomInstances() throws Exception {
+
+		// arrange
 		int numberOfInstances = 100;
-		double iteration = 100;
-
 		List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
 		List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
 
@@ -132,166 +482,23 @@ public class OfoFastThresholdTunerTests {
 			predictedLabels.add(new HashSet<Integer>(getRandomInts()));
 		}
 
-		// act
-		double elapsed1 = 0, elapsed2 = 0;
-		for (int i = 0; i < iteration; i++) {
-			long startTime1 = System.nanoTime();
-			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
-			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
-
-			long startTime2 = System.nanoTime();
-			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
-			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
+		Map<String, Object> tuningData = new HashMap<String, Object>();
+		tuningData.put(Constants.ThresholdTuningDictKeys.trueLabels, trueLabels);
+		tuningData.put(Constants.ThresholdTuningDictKeys.predictedLabels, predictedLabels);
+		Set<Integer> expected = new HashSet<Integer>();
+		for (HashSet<Integer> labels : trueLabels) {
+			expected.addAll(labels);
 		}
-		// Assert
-		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the original method : "
-				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
-		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the set based  method : "
-				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
-		assert (true);// nothing to assert
-	}
-
-	@Test
-	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances1K() {
-		// Arrange
-		int numberOfInstances = 1000;
-		double iteration = 100;
-		double elapsed1 = 0, elapsed2 = 0;
-		for (int k = 0; k < iteration; k++) {
-			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
-			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
-
-			for (int i = 0; i < numberOfInstances; i++) {
-				trueLabels.add(new HashSet<Integer>(getRandomInts()));
-				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
-			}
-
-			// act
-
-			long startTime1 = System.nanoTime();
-			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
-			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
-
-			long startTime2 = System.nanoTime();
-			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
-			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
-		}
-		// Assert
-		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the original method : "
-				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
-		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the set based  method : "
-				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
-		assert (true);// nothing to assert
-	}
-
-	@Test
-	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances10K() {
-		// Arrange
-		int numberOfInstances = 10000;
-		double iteration = 1000;
-		double elapsed1 = 0, elapsed2 = 0;
-		for (int k = 0; k < iteration; k++) {
-			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
-			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
-
-			for (int i = 0; i < numberOfInstances; i++) {
-				trueLabels.add(new HashSet<Integer>(getRandomInts()));
-				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
-			}
-
-			// act
-
-			long startTime1 = System.nanoTime();
-			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
-			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
-
-			long startTime2 = System.nanoTime();
-			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
-			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
-		}
-		// Assert
-		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the original method : "
-				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
-		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the set based  method : "
-				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
-		assert (true);// nothing to assert
-	}
-
-	// @Test
-	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances100k() {
-		// Arrange
-		int numberOfInstances = 100000;
-		double iteration = 100;
-		double elapsed1 = 0, elapsed2 = 0;
-		for (int k = 0; k < iteration; k++) {
-			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
-			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
-
-			for (int i = 0; i < numberOfInstances; i++) {
-				trueLabels.add(new HashSet<Integer>(getRandomInts()));
-				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
-			}
-
-			// act
-
-			long startTime1 = System.nanoTime();
-			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
-			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
-
-			long startTime2 = System.nanoTime();
-			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
-			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
-		}
-		// Assert
-		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the original method : "
-				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
-		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the set based  method : "
-				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
-		assert (true);// nothing to assert
-	}
-
-	// @Test
-	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances1M() {
-		// Arrange
-		int numberOfInstances = 1000000;
-		double iteration = 100;
-
-		List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
-		List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
-
-		for (int i = 0; i < numberOfInstances; i++) {
-			trueLabels.add(new HashSet<Integer>(getRandomInts()));
-			predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+		for (HashSet<Integer> labels : predictedLabels) {
+			expected.addAll(labels);
 		}
 
 		// act
-		double elapsed1 = 0, elapsed2 = 0;
-		for (int i = 0; i < iteration; i++) {
-			long startTime1 = System.nanoTime();
-			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
-			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
+		Map<Integer, Double> sparseThresholds = target.getTunedThresholdsSparse(tuningData);
+		Set<Integer> actual = sparseThresholds.keySet();
 
-			long startTime2 = System.nanoTime();
-			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
-			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
-		}
-		// Assert
-		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the original method : "
-				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
-		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
-				+ " instances by the set based  method : "
-				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
-		assert (true);// nothing to assert
+		// assert
+		assertTrue(expected.equals(actual));
 	}
-*/
-	// END performance tests
+
 }

--- a/XMLC/tests/threshold/OfoFastThresholdTunerTests.java
+++ b/XMLC/tests/threshold/OfoFastThresholdTunerTests.java
@@ -1,0 +1,297 @@
+package threshold;
+
+import static org.junit.Assert.*;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OfoFastThresholdTunerTests {
+	OfoFastThresholdTuner target;
+	int numberOfLabels = 50000;
+	int maximumNumberOfLabelsPerInstance = 5;
+	private static DecimalFormat df2 = new DecimalFormat(".##");
+
+	@Before
+	public void arrange() {
+		target = new OfoFastThresholdTuner(numberOfLabels, null);
+	}
+
+	@After
+	public void tearDown() {
+		target = null;
+	}
+
+	private List<Integer> getRandomInts() {
+
+		int numberOfLabels = ThreadLocalRandom.current()
+				.nextInt(1, maximumNumberOfLabelsPerInstance + 1);
+
+		ArrayList<Integer> retVal = new ArrayList<>();
+
+		for (int i = 0; i < numberOfLabels; i++)
+			retVal.add(ThreadLocalRandom.current()
+					.nextInt(numberOfLabels));
+
+		return retVal;
+	}
+
+	// START performance tests
+	// To run below tests on performance benchmark on tuneAndGetAffectedLabels and tuneAndGetAffectedLabels1,
+	// change the access modifiers of those.
+/*
+	@Test
+	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_SingleInstances() {
+		// Arrange
+		int numberOfInstances = 1;
+		double iteration = 100000000;
+		double elapsed1 = 0, elapsed2 = 0;
+
+		for (int k = 0; k < iteration; k++) {
+			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
+
+			for (int i = 0; i < numberOfInstances; i++) {
+				trueLabels.add(new HashSet<Integer>(getRandomInts()));
+				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+			}
+
+			// act
+
+			long startTime1 = System.nanoTime();
+			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
+
+			long startTime2 = System.nanoTime();
+			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
+			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
+		}
+
+		// Assert
+		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the original method : "
+				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
+		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the set based  method : "
+				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
+		assert (true);// nothing to assert
+	}
+
+	@Test
+	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances10() {
+		// Arrange
+		int numberOfInstances = 10;
+		double iteration = 1000000;
+		double elapsed1 = 0, elapsed2 = 0;
+		for (int k = 0; k < iteration; k++) {
+			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
+
+			for (int i = 0; i < numberOfInstances; i++) {
+				trueLabels.add(new HashSet<Integer>(getRandomInts()));
+				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+			}
+
+			// act
+
+			long startTime1 = System.nanoTime();
+			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
+
+			long startTime2 = System.nanoTime();
+			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
+			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
+		}
+		// Assert
+		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the original method : "
+				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
+		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the set based  method : "
+				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
+		assert (true);// nothing to assert
+	}
+
+	@Test
+	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances100() {
+		// Arrange
+		int numberOfInstances = 100;
+		double iteration = 100;
+
+		List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+		List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
+
+		for (int i = 0; i < numberOfInstances; i++) {
+			trueLabels.add(new HashSet<Integer>(getRandomInts()));
+			predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+		}
+
+		// act
+		double elapsed1 = 0, elapsed2 = 0;
+		for (int i = 0; i < iteration; i++) {
+			long startTime1 = System.nanoTime();
+			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
+
+			long startTime2 = System.nanoTime();
+			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
+			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
+		}
+		// Assert
+		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the original method : "
+				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
+		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the set based  method : "
+				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
+		assert (true);// nothing to assert
+	}
+
+	@Test
+	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances1K() {
+		// Arrange
+		int numberOfInstances = 1000;
+		double iteration = 100;
+		double elapsed1 = 0, elapsed2 = 0;
+		for (int k = 0; k < iteration; k++) {
+			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
+
+			for (int i = 0; i < numberOfInstances; i++) {
+				trueLabels.add(new HashSet<Integer>(getRandomInts()));
+				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+			}
+
+			// act
+
+			long startTime1 = System.nanoTime();
+			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
+
+			long startTime2 = System.nanoTime();
+			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
+			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
+		}
+		// Assert
+		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the original method : "
+				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
+		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the set based  method : "
+				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
+		assert (true);// nothing to assert
+	}
+
+	@Test
+	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances10K() {
+		// Arrange
+		int numberOfInstances = 10000;
+		double iteration = 1000;
+		double elapsed1 = 0, elapsed2 = 0;
+		for (int k = 0; k < iteration; k++) {
+			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
+
+			for (int i = 0; i < numberOfInstances; i++) {
+				trueLabels.add(new HashSet<Integer>(getRandomInts()));
+				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+			}
+
+			// act
+
+			long startTime1 = System.nanoTime();
+			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
+
+			long startTime2 = System.nanoTime();
+			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
+			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
+		}
+		// Assert
+		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the original method : "
+				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
+		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the set based  method : "
+				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
+		assert (true);// nothing to assert
+	}
+
+	// @Test
+	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances100k() {
+		// Arrange
+		int numberOfInstances = 100000;
+		double iteration = 100;
+		double elapsed1 = 0, elapsed2 = 0;
+		for (int k = 0; k < iteration; k++) {
+			List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+			List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
+
+			for (int i = 0; i < numberOfInstances; i++) {
+				trueLabels.add(new HashSet<Integer>(getRandomInts()));
+				predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+			}
+
+			// act
+
+			long startTime1 = System.nanoTime();
+			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
+
+			long startTime2 = System.nanoTime();
+			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
+			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
+		}
+		// Assert
+		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the original method : "
+				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
+		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the set based  method : "
+				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
+		assert (true);// nothing to assert
+	}
+
+	// @Test
+	public void performanceComparisonBetweenSetBasedTuningAndOldSchool_NumberOfInstances1M() {
+		// Arrange
+		int numberOfInstances = 1000000;
+		double iteration = 100;
+
+		List<HashSet<Integer>> trueLabels = new ArrayList<HashSet<Integer>>();
+		List<HashSet<Integer>> predictedLabels = new ArrayList<HashSet<Integer>>();
+
+		for (int i = 0; i < numberOfInstances; i++) {
+			trueLabels.add(new HashSet<Integer>(getRandomInts()));
+			predictedLabels.add(new HashSet<Integer>(getRandomInts()));
+		}
+
+		// act
+		double elapsed1 = 0, elapsed2 = 0;
+		for (int i = 0; i < iteration; i++) {
+			long startTime1 = System.nanoTime();
+			target.tuneAndGetAffectedLabels(predictedLabels, trueLabels);
+			elapsed1 += (double) (System.nanoTime() - startTime1) / iteration;
+
+			long startTime2 = System.nanoTime();
+			target.tuneAndGetAffectedLabels1(predictedLabels, trueLabels);
+			elapsed2 += (double) (System.nanoTime() - startTime2) / iteration;
+		}
+		// Assert
+		System.out.println("Average (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the original method : "
+				+ df2.format(elapsed1 / (1000.0 * numberOfInstances)) + " ms.");
+		System.out.println("Average  (over " + iteration + " iterations) time taken for " + numberOfInstances
+				+ " instances by the set based  method : "
+				+ df2.format(elapsed2 / (1000.0 * numberOfInstances)) + " ms.");
+		assert (true);// nothing to assert
+	}
+*/
+	// END performance tests
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 				<version>3.1</version>
 				<configuration>
 					<source>1.7</source>
-					<target>1.7</target>					
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -37,8 +37,8 @@
 					</execution>
 				</executions>
 				<configuration>
-				    <finalName>XMLC_PLT</finalName>
-				    <outputDirectory>./</outputDirectory>
+					<finalName>XMLC_PLT</finalName>
+					<outputDirectory>./</outputDirectory>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
@@ -96,6 +96,11 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>20.0</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
**Feature suggestion:** Make the dependency from ThresholdTuning --> Learner to Learner --> ThresholdTuning. The existing code to tune the threshold might not be plugable as they are doing so many things. If those can be make lean, the dependency can be revered, and threshold can be tuned from the learners.

Thus, in this pull request, tried to do that; created a sample implementation, and integrated that.
- Created an abstract ThresholdTuner, which is able to provide tuned thresholds, both dense and sparse.
- Added an implementation for OfoFast as a sample.
- Integrated the ThresholdTuner with AbstractLearner (more specifically PLT).

However, note that this is an optional step now, as right now it does not provide threshold tuner implementations for all. Thus, the existing code should work as it should.

Additionally, made some cleanup, and added some unit tests.